### PR TITLE
Fix JavaDoc build failure

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,9 +21,5 @@ jobs:
       with:
         java-version: 1.8
         java-package: jdk
-    - name: inspect java env
-      run: set | grep JAVA
-    - name: inspect java bin
-      run: ls $JAVA_HOME/bin
     - name: Build with Maven
-      run: mvn -X -B package --file pom.xml
+      run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,5 @@ jobs:
         java-package: jdk
     - name: inspect java env
       run: set | grep JAVA
-      run: ls $JAVA_HOME/bin
-      run: ls $JAVA_HOME
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,5 +20,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+        java-package: jdk
+    - name: inspect java env
+      run: set | grep JAVA
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,5 +23,7 @@ jobs:
         java-package: jdk
     - name: inspect java env
       run: set | grep JAVA
+      run: ls $JAVA_HOME/bin
+      run: ls $JAVA_HOME
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,5 +23,7 @@ jobs:
         java-package: jdk
     - name: inspect java env
       run: set | grep JAVA
+    - name: inspect java bin
+      run: ls $JAVA_HOME/bin
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -X -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 				<configuration>
 					<quiet>true</quiet>
 					<source>8</source>
-					<javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+					<javadocExecutable>${env.JAVA_HOME}/bin/javadoc</javadocExecutable>
 					<additionalparam>-Xdoclint:none</additionalparam>
 				</configuration>
 				<executions>


### PR DESCRIPTION
Fix a build failure caused by the `java.home` system property pointing to the JRE instead of `JAVA_HOME`