### PR TITLE
Resolve issues with listed license references

### DIFF
--- a/src/main/java/org/spdx/spdxRdfStore/RdfStore.java
+++ b/src/main/java/org/spdx/spdxRdfStore/RdfStore.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.query.ARQ;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.util.FileManager;
@@ -71,6 +72,9 @@ public class RdfStore implements IModelStore, ISerializableModelStore {
 	
 	private OutputFormat outputFormat = OutputFormat.XML_ABBREV;
 
+	static {
+		ARQ.init();		// Insure ARQ is initialized
+	}
 	
 
 	/**


### PR DESCRIPTION
Fix issue with listed license references in the RDF model when the resource is not defined in the same model.  Also addresses issues with URL encoding in IDs

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>