### PR TITLE
Fix ID type checking

### DIFF
--- a/src/main/java/org/spdx/spdxRdfStore/RdfStore.java
+++ b/src/main/java/org/spdx/spdxRdfStore/RdfStore.java
@@ -114,13 +114,13 @@ public class RdfStore implements IModelStore, ISerializableModelStore {
 		if (ANON_ID_PATTERN.matcher(id).matches()) {
 			return IdType.Anonymous;
 		}
-		if (SpdxConstants.LICENSE_ID_PATTERN_NUMERIC.matcher(id).matches()) {
+		if (SpdxConstants.LICENSE_ID_PATTERN.matcher(id).matches()) {
 			return IdType.LicenseRef;
 		}
-		if (DOCUMENT_ID_PATTERN_NUMERIC.matcher(id).matches()) {
+		if (SpdxConstants.EXTERNAL_DOC_REF_PATTERN.matcher(id).matches()) {
 			return IdType.DocumentRef;
 		}
-		if (SPDX_ID_PATTERN_NUMERIC.matcher(id).matches()) {
+		if (SpdxConstants.SPDX_ELEMENT_REF_PATTERN.matcher(id).matches()) {
 			return IdType.SpdxId;
 		}
 		if (LITERAL_VALUE_SET.contains(id)) {

--- a/src/test/java/org/spdx/library/model/SpdxElementTest.java
+++ b/src/test/java/org/spdx/library/model/SpdxElementTest.java
@@ -85,7 +85,7 @@ public class SpdxElementTest extends TestCase {
 	 * @throws InvalidSPDXAnalysisException 
 	 */
 	public void testVerify() throws InvalidSPDXAnalysisException {
-		String id = "elementId";
+		String id = "SPDXRef-elementId";
 		SpdxElement element1 = new GenericSpdxElement(gmo.getModelStore(), gmo.getDocumentUri(), id, gmo.getCopyManager(), true);
 		assertEquals(0, element1.verify().size());
 		element1.setName(ELEMENT_NAME1);


### PR DESCRIPTION
Related to issue https://github.com/spdx/spdx-java-jackson-store/issues/7

Change the ID type checking to check for all valid SpdxElement ID's, SPDX document reference IDs and SPDX License Reference ID's.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>