### PR TITLE
Update SPDX Java Library version to 1.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.spdx</groupId>
   <artifactId>spdx-rdf-store</artifactId>
-  <version>1.0.4-SNAPSHOT</version>
+  <version>1.0.4</version>
   <packaging>jar</packaging>
 
   <name>spdx-rdf-store</name>
@@ -91,7 +91,7 @@
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>java-spdx-library</artifactId>
-    	<version>1.0.9</version>
+    	<version>1.0.10</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.jena</groupId>
@@ -202,7 +202,7 @@
 			<plugin>
 				<groupId>org.spdx</groupId>
 					<artifactId>spdx-maven-plugin</artifactId>
-					<version>0.5.3</version>
+					<version>0.5.5</version>
 					<executions>
 						<execution>
 							<id>build-spdx</id>


### PR DESCRIPTION
Updates log4j to version 2.17.0 resolving possible vulnerabilities
CVE-2021-44228 and CVE-2021-45046

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>