### PR TITLE
Fetch listed license/exceptions from listedLiceses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>java-spdx-library</artifactId>
-    	<version>1.1.0</version>
+    	<version>1.1.1</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.jena</groupId>

--- a/src/main/java/org/spdx/spdxRdfStore/RdfSpdxDocumentModelManager.java
+++ b/src/main/java/org/spdx/spdxRdfStore/RdfSpdxDocumentModelManager.java
@@ -665,7 +665,7 @@ public class RdfSpdxDocumentModelManager implements IModelStoreLock {
 			Property property = model.createProperty(SpdxResourceFactory.propertyNameToUri(propertyName));
 			NodeIterator iter = model.listObjectsOfProperty(idResource, property);
 			if (!iter.hasNext()) {
-				if (isListedLicenseOrException(idResource)) {
+				if (isListedLicenseOrException(idResource) && !this.exists(id)) {
 					// If there is no locally stored property for a listed license or exception
 					// fetch it from listed licenses store
 					return ListedLicenses.getListedLicenses().getLicenseModelStore()

--- a/src/main/java/org/spdx/spdxRdfStore/SpdxOwlOntology.java
+++ b/src/main/java/org/spdx/spdxRdfStore/SpdxOwlOntology.java
@@ -219,13 +219,13 @@ public class SpdxOwlOntology {
 			if (classUri.endsWith("GenericSpdxElement")) {
 				ontClass = model.getOntClass(SpdxConstants.SPDX_NAMESPACE + SpdxConstants.CLASS_SPDX_ELEMENT);
 			} else {
-				logger.error(classUri + " is not an SPDX class");
+				logger.warn(classUri + " is not an SPDX class");
 				throw new SpdxRdfException(classUri + " is not an SPDX class");
 			}
 		}
 		OntProperty property = model.getOntProperty(checkGetOwlUriFromRenamed(propertyUri));
 		if (Objects.isNull(property)) {
-			logger.error(propertyUri + " is not an SPDX property");
+			logger.warn(propertyUri + " is not an SPDX property");
 			throw new MissingDataTypeAndClassRestriction(propertyUri + " is not an SPDX property");
 		}
 		List<Statement> propertyRestrictions = new ArrayList<Statement>();
@@ -253,13 +253,13 @@ public class SpdxOwlOntology {
 			if (classUri.endsWith("GenericSpdxElement")) {
 				ontClass = model.getOntClass(SpdxConstants.SPDX_NAMESPACE + SpdxConstants.CLASS_SPDX_ELEMENT);
 			} else {
-				logger.error(classUri + " is not an SPDX class");
+				logger.warn(classUri + " is not an SPDX class");
 				throw new SpdxRdfException(classUri + " is not an SPDX class");
 			}
 		}
 		OntProperty property = model.getOntProperty(checkGetOwlUriFromRenamed(propertyUri));
 		if (Objects.isNull(property)) {
-			logger.error(propertyUri + " is not an SPDX property");
+			logger.warn(propertyUri + " is not an SPDX property");
 			throw new SpdxRdfException(propertyUri + " is not an SPDX property");
 		}
 		List<Statement> propertyRestrictions = new ArrayList<Statement>();
@@ -287,13 +287,13 @@ public class SpdxOwlOntology {
 			if (classUri.endsWith("GenericSpdxElement")) {
 				ontClass = model.getOntClass(SpdxConstants.SPDX_NAMESPACE + SpdxConstants.CLASS_SPDX_ELEMENT);
 			} else {
-				logger.error(classUri + " is not an SPDX class");
+				logger.warn(classUri + " is not an SPDX class");
 				throw new SpdxRdfException(classUri + " is not an SPDX class");
 			}
 		}
 		OntProperty property = model.getOntProperty(checkGetOwlUriFromRenamed(propertyUri));
 		if (Objects.isNull(property)) {
-			logger.error(propertyUri + " is not an SPDX property");
+			logger.warn(propertyUri + " is not an SPDX property");
 			throw new SpdxRdfException(propertyUri + " is not an SPDX property");
 		}
 		List<Statement> propertyRestrictions = new ArrayList<Statement>();

--- a/src/test/java/org/spdx/library/model/license/SpdxListedLicenseTest.java
+++ b/src/test/java/org/spdx/library/model/license/SpdxListedLicenseTest.java
@@ -20,7 +20,6 @@ package org.spdx.library.model.license;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
If the properties are not stored in the local document, fetch from the listed licenses.

Fixes #32

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>