### PR TITLE
Check for an existing value in getTypedValue

### DIFF
--- a/src/main/java/org/spdx/spdxRdfStore/RdfSpdxDocumentModelManager.java
+++ b/src/main/java/org/spdx/spdxRdfStore/RdfSpdxDocumentModelManager.java
@@ -1286,16 +1286,22 @@ public class RdfSpdxDocumentModelManager implements IModelStoreLock {
 	}
 
 	/**
-	 * @param id
+	 * @param id associated with a type
 	 * @return Type typed value for the ID if it exists and is of an SPDX type, otherwise empty
 	 * @throws InvalidSPDXAnalysisException
 	 */
 	public Optional<TypedValue> getTypedValue(String id) throws InvalidSPDXAnalysisException {
 		Objects.requireNonNull(id, "Missing required ID");
+		if (!exists(id)) {
+			return Optional.empty();
+		}
 		model.enterCriticalSection(false);
 		try {
 			try {
 				Resource idResource = idToResource(id);
+				if (!this.model.containsResource(idResource)) {
+					return Optional.empty();
+				}
 				Resource idClass = idToClass(idResource);
 				if (Objects.isNull(idClass)) {
 					return Optional.empty();


### PR DESCRIPTION
This additional check is needed due to a change in the ModelStore for version 1.1.1 of the SPDX Java Library which expecteds getTypedValue to return empty if the ID does not exist

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>