### PR TITLE
Fix NPE in CompatibilityUpgrader

### DIFF
--- a/src/main/java/org/spdx/spdxRdfStore/CompatibilityUpgrader.java
+++ b/src/main/java/org/spdx/spdxRdfStore/CompatibilityUpgrader.java
@@ -132,7 +132,8 @@ public class CompatibilityUpgrader {
 	            	Resource existingRelationship = stmt.getObject().asResource();
 	            	Resource relatedElement = existingRelationship.getPropertyResourceValue(model.createProperty(SpdxConstants.SPDX_NAMESPACE + SpdxConstants.PROP_RELATED_SPDX_ELEMENT));
 	            	Resource relationshipType = existingRelationship.getPropertyResourceValue(model.createProperty(SpdxConstants.SPDX_NAMESPACE + SpdxConstants.PROP_RELATIONSHIP_TYPE));
-	            	if (relatedElement.isURIResource() && relatedElement.getURI().equals(file.getURI()) &&
+	            	if (relatedElement.isURIResource() && file.isURIResource() && relationshipType.isURIResource() &&
+	            			relatedElement.getURI().equals(file.getURI()) &&
 	            			relationshipType.getURI().equals(RelationshipType.CONTAINS.getIndividualURI())) {
 	            		foundContainsRelationships.add(stmt);
             		}
@@ -292,7 +293,7 @@ public class CompatibilityUpgrader {
 	                statementsToRemove.add(iter.next());
 	            }
 	            Resource pkg = convertDoapProjectToSpdxPackage(model, doapProject, docNamespace + idPrefix + Integer.toString(nextSpdxIdNum));
-	            if (!addedDoapProjects.contains(pkg.getURI())) {
+	            if (pkg.isURIResource() && !addedDoapProjects.contains(pkg.getURI())) {
 	                addedDoapProjects.add(pkg.getURI());
 	                nextSpdxIdNum = getNexId(model, docNamespace, idPrefix, nextSpdxIdNum);
 	                Resource relationship = createRelationship(model, pkg, RelationshipType.GENERATED_FROM);

--- a/src/main/java/org/spdx/spdxRdfStore/CompatibilityUpgrader.java
+++ b/src/main/java/org/spdx/spdxRdfStore/CompatibilityUpgrader.java
@@ -132,7 +132,7 @@ public class CompatibilityUpgrader {
 	            	Resource existingRelationship = stmt.getObject().asResource();
 	            	Resource relatedElement = existingRelationship.getPropertyResourceValue(model.createProperty(SpdxConstants.SPDX_NAMESPACE + SpdxConstants.PROP_RELATED_SPDX_ELEMENT));
 	            	Resource relationshipType = existingRelationship.getPropertyResourceValue(model.createProperty(SpdxConstants.SPDX_NAMESPACE + SpdxConstants.PROP_RELATIONSHIP_TYPE));
-	            	if (relatedElement.getURI().equals(file.getURI()) &&
+	            	if (relatedElement.isURIResource() && relatedElement.getURI().equals(file.getURI()) &&
 	            			relationshipType.getURI().equals(RelationshipType.CONTAINS.getIndividualURI())) {
 	            		foundContainsRelationships.add(stmt);
             		}


### PR DESCRIPTION
This happens when there is an anonomous element referenced in a package relationship.

Note that this should not happen in a valid SPDX documents since all elements must have SPDXRef- ID's which will generate a URI reference.

This fixes one of the issues referenced in https://github.com/spdx/tools-python/issues/255

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>