### PR TITLE
Update POM with correct Java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.1</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<release>11</release>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>
-				<jdk>[1.8,)</jdk>
+				<jdk>[1.8,11)</jdk>
 			</activation>
 			<properties>
 				<javadoc.opts>-Xdoclint:none</javadoc.opts>
@@ -161,8 +161,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 	<sonar.organization>spdx</sonar.organization>
 	<sonar.projectKey>spdx-rdf-store</sonar.projectKey>
 	<dependency-check-maven.version>8.0.1</dependency-check-maven.version>
+	<javadoc.opts>-Xdoclint:none</javadoc.opts>
   </properties>
   
     <licenses>
@@ -47,15 +48,6 @@
 	</distributionManagement>
 
 	<profiles>
-		<profile>
-			<id>doclint-java8-disable</id>
-			<activation>
-				<jdk>[1.8,11)</jdk>
-			</activation>
-			<properties>
-				<javadoc.opts>-Xdoclint:none</javadoc.opts>
-			</properties>
-		</profile>
 		<profile>
 			<id>gpg-signing</id>
 			<build>


### PR DESCRIPTION
The Jena library requires Java 11.  This updates the POM file to target Java 11.

Related to https://github.com/spdx/spdx-maven-plugin/issues/76

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>