### PR TITLE
Fix unit test failures

### DIFF
--- a/TestFiles/SPDXRdfExampleHttps.rdf
+++ b/TestFiles/SPDXRdfExampleHttps.rdf
@@ -1123,6 +1123,7 @@ under the Apache License 2.0 (see: StringUtils.containsWhitespace())</spdx:notic
                                 <spdx:relatedSpdxElement>
                                   <spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Saxon">
                                     <spdx:name>Saxon</spdx:name>
+                                    <spdx:copyrightText>NOASSERTION</spdx:copyrightText>
                                     <spdx:checksum>
                                       <spdx:Checksum>
                                         <spdx:checksumValue>85ed0817af83a24ad8da68c2b5094de69833983c</spdx:checksumValue>

--- a/src/main/java/org/spdx/spdxRdfStore/RdfSpdxDocumentModelManager.java
+++ b/src/main/java/org/spdx/spdxRdfStore/RdfSpdxDocumentModelManager.java
@@ -72,6 +72,7 @@ import org.spdx.library.SpdxInvalidIdException;
 import org.spdx.library.model.DuplicateSpdxIdException;
 import org.spdx.library.model.IndividualUriValue;
 import org.spdx.library.model.SimpleUriValue;
+import org.spdx.library.model.SpdxIdNotFoundException;
 import org.spdx.library.model.SpdxInvalidTypeException;
 import org.spdx.library.model.SpdxModelFactory;
 import org.spdx.library.model.TypedValue;
@@ -667,11 +668,15 @@ public class RdfSpdxDocumentModelManager implements IModelStoreLock {
 			Property property = model.createProperty(SpdxResourceFactory.propertyNameToUri(propertyName));
 			NodeIterator iter = model.listObjectsOfProperty(idResource, property);
 			if (!iter.hasNext()) {
-				if (isListedLicenseOrException(idResource) && !this.exists(id)) {
+				if (isListedLicenseOrException(idResource)) {
 					// If there is no locally stored property for a listed license or exception
 					// fetch it from listed licenses store
-					return ListedLicenses.getListedLicenses().getLicenseModelStore()
-							.getValue(HTTPS_LISTED_LICENSE_NAMESPACE_PREFIX, id, propertyName);
+					try {
+						return ListedLicenses.getListedLicenses().getLicenseModelStore()
+								.getValue(HTTPS_LISTED_LICENSE_NAMESPACE_PREFIX, id, propertyName);
+					} catch(SpdxIdNotFoundException e) {
+						return Optional.empty();
+					}
 				} else {
 					return Optional.empty();
 				}

--- a/src/test/java/org/spdx/library/model/license/SpdxListedLicenseTest.java
+++ b/src/test/java/org/spdx/library/model/license/SpdxListedLicenseTest.java
@@ -178,7 +178,7 @@ public class SpdxListedLicenseTest extends TestCase {
 	public void testSetFsfLibre() throws InvalidSPDXAnalysisException {
 
 		String name = "name";
-		String id = "AFL-3.0";
+		String id = "DIFFERENT";
 		String text = "text";
 		Collection<String> sourceUrls = new ArrayList<String>(Arrays.asList(new String[] {"source url1", "source url2"}));
 		String notes = "notes";


### PR DESCRIPTION
Failures caused by spdx/Spdx-Java-Library#159
Change RDF store to check the listed licenses for any missing properties even if there is a definition in the RDF file.  Somehow the type gets copied over when accessing any of the list license properties.