### PR TITLE
Updating Jena to version 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,17 +123,17 @@
     <dependency>
     	<groupId>org.apache.jena</groupId>
     	<artifactId>jena-core</artifactId>
-    	<version>4.10.0</version>
+    	<version>5.2.0</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.jena</groupId>
     	<artifactId>jena-arq</artifactId>
-    	<version>4.10.0</version>
+    	<version>5.2.0</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.jena</groupId>
     	<artifactId>jena-base</artifactId>
-    	<version>4.10.0</version>
+    	<version>5.2.0</version>
     </dependency>
   </dependencies>
     <build>

--- a/src/main/java/org/spdx/spdxRdfStore/SpdxOwlOntology.java
+++ b/src/main/java/org/spdx/spdxRdfStore/SpdxOwlOntology.java
@@ -35,7 +35,6 @@ import org.apache.jena.ontology.OntProperty;
 import org.apache.jena.ontology.OntResource;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.SimpleSelector;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.util.iterator.ExtendedIterator;
 import org.slf4j.Logger;
@@ -331,11 +330,9 @@ public class SpdxOwlOntology {
 	 */
 	private void addPropertyRestrictions(OntClass ontClass, OntProperty property, List<Statement> propertyRestrictions) {	
 		if (ontClass.isRestriction()) {
-			if (model.listStatements(new SimpleSelector(ontClass, ON_PROPERTY_PROPERTY, property)).hasNext()) {
+			if (model.listStatements(ontClass, ON_PROPERTY_PROPERTY, property).hasNext()) {
 				// matches the property
-				ontClass.listProperties().forEachRemaining((Statement stmt) -> {
-					propertyRestrictions.add(stmt);
-				});
+				ontClass.listProperties().forEachRemaining(propertyRestrictions::add);
 			}
 		} else if (ontClass.isUnionClass()) {
 			ontClass.asUnionClass().listOperands().forEachRemaining((OntClass operand) -> {


### PR DESCRIPTION
The Jena dependency version 4.10.2 which is currently used introduces a dependency that has a reported vulnerability.

This merge request updates Jena. The test suite seems unaffected. As I'm new to this repo and I havent applied this updated version elsewhere I don't know whether this update will have side effects.