### PR TITLE
Update and add missing header and Javadoc

### DIFF
--- a/src/main/java/org/spdx/spdxRdfStore/CompatibilityUpgrader.java
+++ b/src/main/java/org/spdx/spdxRdfStore/CompatibilityUpgrader.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +48,6 @@ import org.spdx.library.model.v2.enumerations.RelationshipType;
 /**
  * Updates the RDF model for compatibility with the current version of the spec
  * @author Gary O'Neall
- *
  */
 public class CompatibilityUpgrader {
 	

--- a/src/main/java/org/spdx/spdxRdfStore/MissingDataTypeAndClassRestriction.java
+++ b/src/main/java/org/spdx/spdxRdfStore/MissingDataTypeAndClassRestriction.java
@@ -1,7 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +21,6 @@ package org.spdx.spdxRdfStore;
  * Exceptions related to missing restrictions in the SPDX OWL ontology
  * 
  * @author Gary O'Neall
- *
  */
 public class MissingDataTypeAndClassRestriction extends SpdxRdfException {
 

--- a/src/main/java/org/spdx/spdxRdfStore/OutputFormat.java
+++ b/src/main/java/org/spdx/spdxRdfStore/OutputFormat.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +19,7 @@ package org.spdx.spdxRdfStore;
 
 /**
  * Formats supported for serializing RDF
- * 
- * 
+ *
  * @author Gary O'Neall
  */
 public enum OutputFormat {

--- a/src/main/java/org/spdx/spdxRdfStore/RdfSpdxModelManager.java
+++ b/src/main/java/org/spdx/spdxRdfStore/RdfSpdxModelManager.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -85,7 +85,6 @@ import org.spdx.storage.IModelStore.IModelStoreLock;
  * If a URI type, the ID namespace is either the listed license namespace or the document URI.
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("LoggingSimilarMessage")
 public class RdfSpdxModelManager implements IModelStoreLock {
@@ -102,12 +101,22 @@ public class RdfSpdxModelManager implements IModelStoreLock {
      * subset of the listed license namespace to be used for matching
      */
     private static final CharSequence SPDX_LISTED_LICENSE_SUBPREFIX = "://spdx.org/licenses/";
-	
+
+	/**
+	 * An iterator for traversing RDF list objects associated with a specific property of a resource
+	 */
 	public class RdfListIterator implements Iterator<Object> {
-		
+
 		final NodeIterator listIterator;
 		private final Property property;
 
+		/**
+		 * Constructs an RdfListIterator for a given resource and property
+		 *
+		 * @param idResource the resource whose property values are to be iterated
+		 * @param property the property whose values are to be iterated
+		 * @throws NullPointerException if idResource or property is null
+		 */
 		public RdfListIterator(Resource idResource, Property property) {
 			Objects.requireNonNull(idResource, "ID resource can not be null");
 			Objects.requireNonNull(property, "Property resource can not be null");

--- a/src/main/java/org/spdx/spdxRdfStore/RdfStore.java
+++ b/src/main/java/org/spdx/spdxRdfStore/RdfStore.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,7 +57,6 @@ import org.spdx.storage.compatv2.CompatibleModelStoreWrapper;
  * Model Store implemented using RDF
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("LoggingSimilarMessage")
 public class RdfStore implements IModelStore, ISerializableModelStore {

--- a/src/main/java/org/spdx/spdxRdfStore/SpdxOwlOntology.java
+++ b/src/main/java/org/spdx/spdxRdfStore/SpdxOwlOntology.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,6 @@ import org.spdx.library.model.v2.SpdxConstantsCompatV2;
  * Singleton class to manage the OWL ontology
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("LoggingSimilarMessage")
 public class SpdxOwlOntology {

--- a/src/main/java/org/spdx/spdxRdfStore/SpdxRdfException.java
+++ b/src/main/java/org/spdx/spdxRdfStore/SpdxRdfException.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ import org.spdx.core.InvalidSPDXAnalysisException;
  * Exceptions related to RDF storage of SPDX documents
  * 
  * @author Gary O'Neall
- *
  */
 public class SpdxRdfException extends InvalidSPDXAnalysisException {
 	

--- a/src/main/java/org/spdx/spdxRdfStore/SpdxResourceFactory.java
+++ b/src/main/java/org/spdx/spdxRdfStore/SpdxResourceFactory.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,6 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
 package org.spdx.spdxRdfStore;
 
 import java.util.Objects;
@@ -67,9 +66,13 @@ public class SpdxResourceFactory {
 			return ResourceFactory.createResource(SpdxConstantsCompatV2.SPDX_NAMESPACE + type); 
 		}
 	}
-	
+
 	/**
-	 * @return URI for the type or className
+	 * Converts a class name to its corresponding URI
+	 *
+	 * @param className the name of the class to convert to a URI
+	 * @return the URI for the type or the class name
+	 * @throws NullPointerException if the className is null
 	 */
 	public static String classNameToUri(String className) {
 		Objects.requireNonNull(className);

--- a/src/test/java/org/spdx/library/model/compat/v2/AnnotationTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/AnnotationTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -37,8 +36,7 @@ import org.spdx.spdxRdfStore.RdfStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class AnnotationTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/ByteOffsetPointerTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/ByteOffsetPointerTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.util.List;
 
@@ -35,8 +34,7 @@ import org.spdx.spdxRdfStore.RdfStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class ByteOffsetPointerTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/ChecksumTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/ChecksumTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.util.List;
 
@@ -36,8 +35,7 @@ import org.spdx.spdxRdfStore.RdfStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class ChecksumTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/ExternalDocumentRefTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/ExternalDocumentRefTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
-
+package org.spdx.library.model.compat.v2;
 
 import java.util.Optional;
 
@@ -40,8 +38,7 @@ import org.spdx.spdxRdfStore.RdfStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class ExternalDocumentRefTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/ExternalRefTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/ExternalRefTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -41,7 +40,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class ExternalRefTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/ExternalSpdxElementTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/ExternalSpdxElementTest.java
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.library.model.compat.v2;
 
 

--- a/src/test/java/org/spdx/library/model/compat/v2/IndividualUriValueTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/IndividualUriValueTest.java
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.library.model.compat.v2;
 
 

--- a/src/test/java/org/spdx/library/model/compat/v2/LineCharPointerTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/LineCharPointerTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
-
+package org.spdx.library.model.compat.v2;
 
 import java.util.List;
 
@@ -36,8 +34,7 @@ import org.spdx.spdxRdfStore.RdfStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class LineCharPointerTest extends TestCase {
 

--- a/src/test/java/org/spdx/library/model/compat/v2/ModelCollectionTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/ModelCollectionTest.java
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.library.model.compat.v2;
 
 

--- a/src/test/java/org/spdx/library/model/compat/v2/NoAssertionElementTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/NoAssertionElementTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
+package org.spdx.library.model.compat.v2;
 
 import org.spdx.core.DefaultModelStore;
 import org.spdx.core.InvalidSPDXAnalysisException;
@@ -33,8 +33,7 @@ import org.spdx.storage.IModelStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class NoAssertionElementTest extends TestCase {
 

--- a/src/test/java/org/spdx/library/model/compat/v2/RelatedElementCollectionTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/RelatedElementCollectionTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,8 +39,7 @@ import org.spdx.spdxRdfStore.RdfStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class RelatedElementCollectionTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/RelationshipTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/RelationshipTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
-
+package org.spdx.library.model.compat.v2;
 
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -60,8 +58,7 @@ import org.spdx.storage.IModelStore.IdType;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class RelationshipTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxConstantElementTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxConstantElementTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.util.ArrayList;
 
@@ -36,8 +35,7 @@ import org.spdx.spdxRdfStore.RdfStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxConstantElementTest extends TestCase {
 

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxCreatorInformationTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxCreatorInformationTest.java
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.library.model.compat.v2;
 
 

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxDocumentTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxDocumentTest.java
@@ -1,7 +1,7 @@
 package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,8 +60,7 @@ import org.spdx.storage.compatv2.CompatibleModelStoreWrapper;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxDocumentTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxElementTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxElementTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.text.SimpleDateFormat;
 import java.util.Collection;
@@ -43,7 +42,7 @@ import org.spdx.storage.IModelStore.IdType;
 import junit.framework.TestCase;
 
 /**
- * @author gary
+  * @author Gary O'Neall
  *
  */
 public class SpdxElementTest extends TestCase {

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxFileTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxFileTest.java
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.library.model.compat.v2;
 
 

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxModelFactoryTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxModelFactoryTest.java
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.library.model.compat.v2;
 
 

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxModelInfoV2_XTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxModelInfoV2_XTest.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.library.model.compat.v2;
 
@@ -34,8 +35,7 @@ import org.spdx.spdxRdfStore.RdfStore;
 import org.spdx.storage.IModelStore;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxModelInfoV2_XTest {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxNoneElementTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxNoneElementTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import org.spdx.core.DefaultModelStore;
 import org.spdx.core.InvalidSPDXAnalysisException;
@@ -34,8 +33,7 @@ import org.spdx.storage.IModelStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxNoneElementTest extends TestCase {
 

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxPackageTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxPackageTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -60,7 +59,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class SpdxPackageTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxPackageVerificationCodeTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxPackageVerificationCodeTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,8 +35,7 @@ import org.spdx.storage.IModelStore.IdType;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxPackageVerificationCodeTest extends TestCase {
 	

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxSnippetTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxSnippetTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -52,8 +51,7 @@ import org.spdx.storage.IModelStore.IdType;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxSnippetTest extends TestCase {
 

--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxVerificationHelperTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxVerificationHelperTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -31,8 +30,7 @@ import org.spdx.library.model.v2.enumerations.ChecksumAlgorithm;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxVerificationHelperTest extends TestCase {
 

--- a/src/test/java/org/spdx/library/model/compat/v2/StartEndPointerTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/StartEndPointerTest.java
@@ -1,7 +1,6 @@
-package org.spdx.library.model.compat.v2;
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * 
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ package org.spdx.library.model.compat.v2;
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
+package org.spdx.library.model.compat.v2;
 
 import java.util.List;
 
@@ -38,8 +37,7 @@ import org.spdx.spdxRdfStore.RdfStore;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class StartEndPointerTest extends TestCase {
 	

--- a/src/test/java/org/spdx/spdxRdfStore/RdfSpdxDocumentModelManagerTest.java
+++ b/src/test/java/org/spdx/spdxRdfStore/RdfSpdxDocumentModelManagerTest.java
@@ -1,5 +1,7 @@
 /**
- * 
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.spdxRdfStore;
 
@@ -27,8 +29,7 @@ import org.spdx.storage.compatv2.CompatibleModelStoreWrapper;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class RdfSpdxDocumentModelManagerTest extends TestCase {
 	

--- a/src/test/java/org/spdx/spdxRdfStore/RdfStoreTest.java
+++ b/src/test/java/org/spdx/spdxRdfStore/RdfStoreTest.java
@@ -1,5 +1,7 @@
 /**
- * 
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.spdxRdfStore;
 
@@ -39,8 +41,7 @@ import org.spdx.storage.compatv2.CompatibleModelStoreWrapper;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class RdfStoreTest extends TestCase {
 

--- a/src/test/java/org/spdx/spdxRdfStore/SpdxOwlOntologyTest.java
+++ b/src/test/java/org/spdx/spdxRdfStore/SpdxOwlOntologyTest.java
@@ -1,5 +1,7 @@
 /**
- * 
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.spdxRdfStore;
 
@@ -15,8 +17,7 @@ import org.spdx.library.model.v2.SpdxConstantsCompatV2;
 import junit.framework.TestCase;
 
 /**
- * @author gary
- *
+ * @author Gary O'Neall
  */
 public class SpdxOwlOntologyTest extends TestCase {
 


### PR DESCRIPTION
- Convert copyright info in header to SPDX FileTag format
- Add missing license info header
- author "gary" -> "Gary O'Neall"
- Add few missing Javadoc for methods and classes