### PR TITLE
Don't allow dates to have decimals

### DIFF
--- a/src/test/java/org/spdx/library/model/compat/v2/SpdxVerificationHelperTest.java
+++ b/src/test/java/org/spdx/library/model/compat/v2/SpdxVerificationHelperTest.java
@@ -96,8 +96,6 @@ public class SpdxVerificationHelperTest extends TestCase {
 		String fullDate = format.format(new Date());
 		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDate(fullDate)));
 		assertFalse(Objects.isNull(SpdxVerificationHelper.verifyDate(new Date().toString())));
-		String withSubSeconds = fullDate.substring(0, fullDate.length()-1) + ".234Z";
-		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDate(withSubSeconds)));
 	}
 
 	/**


### PR DESCRIPTION
Remove a unit test for subseconds.  Required for compatibility with changes in the SPDX Java Library.

See https://github.com/spdx/spdx-java-model-2_X/issues/18